### PR TITLE
extract mixins into separate file

### DIFF
--- a/vendor/assets/stylesheets/animate.scss
+++ b/vendor/assets/stylesheets/animate.scss
@@ -1,24 +1,7 @@
-$animate-scss-speed: 1s !default;
-
-@mixin animate($animation: none, $speed: $animate-scss-speed) {
-  @if $animation != none {
-    -webkit-animation-name: $animation;
-       -moz-animation-name: $animation;
-         -o-animation-name: $animation;
-            animation-name: $animation;
-  }
-  -webkit-animation-duration: $speed;
-     -moz-animation-duration: $speed;
-       -o-animation-duration: $speed;
-          animation-duration: $speed;
-  -webkit-animation-fill-mode: both;
-     -moz-animation-fill-mode: both;
-       -o-animation-fill-mode: both;
-          animation-fill-mode: both;
-}
+@import "animate/_mixins";
 
 body { /* Addresses a small issue in webkit: http://bit.ly/NEdoDq */
-    -webkit-backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
 }
 
 .animated {

--- a/vendor/assets/stylesheets/animate/_mixins.scss
+++ b/vendor/assets/stylesheets/animate/_mixins.scss
@@ -1,0 +1,18 @@
+$animate-scss-speed: 1s !default;
+
+@mixin animate($animation: none, $speed: $animate-scss-speed) {
+  @if $animation != none {
+    -webkit-animation-name: $animation;
+       -moz-animation-name: $animation;
+         -o-animation-name: $animation;
+            animation-name: $animation;
+  }
+  -webkit-animation-duration: $speed;
+     -moz-animation-duration: $speed;
+       -o-animation-duration: $speed;
+          animation-duration: $speed;
+  -webkit-animation-fill-mode: both;
+     -moz-animation-fill-mode: both;
+       -o-animation-fill-mode: both;
+          animation-fill-mode: both;
+}


### PR DESCRIPTION
If you want to use `animate` mixin you need to import animate.scss where it was implemented. 
But this action always adding .animated class and body rule.
So to make css cleaner right now you can just import animate/_mixins, which is include only mixin without additional css
